### PR TITLE
Crowdsale Contract WIP

### DIFF
--- a/dapp/contracts/Boson.sol
+++ b/dapp/contracts/Boson.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.4.18;
+
+contract IBoson {
+    address public cbAddress;
+    function queryAddress(address _address) public payable returns (bytes32 _id);
+}
+
+contract IBosonAddressResolver {
+    function getAddress() public returns (address _address);
+}
+
+contract IBosonCallbackReceiver {
+    function __bosonCallback(bytes32 _id, bool _status) public;
+}

--- a/dapp/contracts/Crowdsale.sol
+++ b/dapp/contracts/Crowdsale.sol
@@ -1,0 +1,210 @@
+pragma solidity ^0.4.17;
+
+import 'zeppelin-solidity/contracts/math/SafeMath.sol';
+import 'zeppelin-solidity/contracts/ownership/Ownable.sol';
+import 'zeppelin-solidity/contracts/token/BurnableToken.sol';
+import 'zeppelin-solidity/contracts/token/StandardToken.sol';
+import 'contracts/Boson.sol';
+
+contract GetToken is BurnableToken, StandardToken {
+    string public name = "GetLine Token";
+    string public symbol = "GET";
+    uint8 public decimals = 3;
+
+    /**
+     * GetToken contructor. Creates the GET token with a fixed supply all
+     * belonging to an owner.
+     * @param _treasury - The owner of all the initial supply of the token.
+     * @param _totalSupply - The initial supply of the token.
+     */
+    function GetToken(address _treasury, uint256 _totalSupply) public {
+        totalSupply = _totalSupply;
+        balances[_treasury] = _totalSupply;
+    }
+}
+
+contract BosonApproved is IBosonCallbackReceiver {
+    IBosonAddressResolver public bosonResolver;
+
+    event ValidationRequest(address _contract, address _who);
+    event ValidationResult(address _contract, address _who, bool _result);
+    struct Validations {
+        uint256 approvals;
+        uint256 rejections;
+    }
+    mapping(bytes32 => address) validationRequests;
+    mapping(address => Validations) validationResults;
+
+    function approved(address _address) public view returns (bool _approved) {
+        _approved = validationResults[_address].approvals > 0;
+    }
+
+    function rejected(address _address) public view returns (bool _rejected) {
+        _rejected = validationResults[_address].rejections > 0;
+    }
+
+    function approve(address _address) public {
+        if (approved(_address)) {
+            return;
+        }
+
+        ValidationRequest(this, _address);
+        bytes32 id = boson().queryAddress(_address);
+        validationRequests[id] = _address;
+    }
+
+    function __bosonCallback(bytes32 _id, bool _status) public {
+        require(msg.sender == boson().cbAddress());
+        address requested = validationRequests[_id];
+        delete validationRequests[_id];
+        ValidationResult(this, requested, _status);
+        if (_status) {
+            validationResults[requested].approvals++;
+            validationResults[requested].rejections = 0;
+        } else {
+            validationResults[requested].rejections++;
+        }
+    }
+
+    function boson() private returns (IBoson _boson) {
+        _boson = IBoson(bosonResolver.getAddress());
+    }
+
+}
+
+contract Crowdsale is Ownable, BosonApproved {
+    uint256 public GOAL_WEI = 10000 ether;
+    uint256 public DURATION = 14 days;
+    uint256 public MINIMUM_PURCHASE_WEI = 1 ether / 100;
+
+    using SafeMath for uint256;
+
+    enum State {
+        Initialized,
+        Started,
+        Finished
+    }
+
+    State public state;
+    GetToken public token;
+
+    uint256 public tokensLeft;
+    uint256 public tokensGoal;
+    uint256 public startDate;
+    uint256 public endDate;
+
+    event StateTransition(uint256 _oldState, uint256 _newState);
+    event StateTimeout(uint256 _oldState);
+
+    function nextState(State _newState) private {
+        StateTransition(uint256(state), uint256(_newState));
+        state = _newState;
+    }
+
+    function processTimeouts() private {
+        if (state == State.Started) {
+            if (block.timestamp > endDate) {
+                StateTimeout(uint256(state));
+                nextState(State.Finished);
+            }
+        }
+    }
+
+    function Crowdsale(GetToken _token, IBosonAddressResolver _bar) public {
+        token = _token;
+        bosonResolver = _bar;
+        owner = msg.sender;
+        state = State.Initialized;
+    }
+
+    function start() onlyOwner public {
+        require(state == State.Initialized);
+
+        state = State.Started;
+        startDate = block.timestamp;
+        endDate = startDate + DURATION;
+        tokensGoal = token.balanceOf(this);
+        tokensLeft = tokensGoal;
+
+        require(tokensGoal > 0);
+        require(price() > 0);
+    }
+
+    function price() public view returns (uint256 _price) {
+        require(state >= State.Started);
+        return GOAL_WEI / tokensGoal;
+    }
+
+    function buy(address buyer) public payable {
+        processTimeouts();
+        require(state == State.Started);
+        require(buyer != 0x0);
+        require(approved(buyer));
+
+        // Convert purchase to requested tokens.
+        uint256 tokens = msg.value.div(price());
+
+        // Make sure to not sell more than we have.
+        if (tokensLeft < tokens) {
+            tokens = tokensLeft;
+        }
+
+        tokensLeft.sub(tokens);
+
+        // Check if crowdsale is done.
+        if (tokensLeft == 0) {
+            nextState(State.Finished);
+        }
+
+        // Send tokens to buyer.
+        require(token.transfer(buyer, tokens));
+    }
+}
+
+contract Treasurer is Ownable {
+    enum State {
+        Initialized,
+        Started
+    }
+
+    address public team;
+    State public state;
+
+    GetToken token_;
+    Crowdsale crowdsale_;
+
+
+    uint256 public initialSupply   = 1000000 * 1000; // 1 million GET tokens.
+    uint256 public teamReserve     =  500000 * 1000; // 0.5 million GET tokens.
+    uint256 public crowdsaleAmount =  500000 * 1000; // 0.5 million GET tokens.
+
+    function Treasurer(address _team) public {
+        team = _team;
+        owner = msg.sender;
+        state = State.Initialized;
+    }
+
+    function start(IBosonAddressResolver _bosonResolver) onlyOwner public {
+        require(state == State.Initialized);
+        state = State.Started;
+
+        GetToken token = new GetToken(this, initialSupply);
+        Crowdsale crowdsale = new Crowdsale(token, _bosonResolver);
+        require(token.transfer(team, teamReserve));
+        require(token.transfer(crowdsale, crowdsaleAmount));
+        crowdsale.start();
+
+        token_ = token;
+        crowdsale_ = crowdsale;
+    }
+
+    function token() public view returns (address _token) {
+        require(state == State.Started);
+        _token = token_;
+    }
+
+    function crowdsale() public view returns (address _crowdsale) {
+        require(state == State.Started);
+        _crowdsale = crowdsale_;
+    }
+}

--- a/dapp/contracts/TestBoson.sol
+++ b/dapp/contracts/TestBoson.sol
@@ -1,0 +1,40 @@
+pragma solidity ^0.4.18;
+
+import 'contracts/Boson.sol';
+
+contract TestBoson is IBoson {
+    mapping(address => uint256) requestCounters;
+    address owner;
+
+    function TestBoson() public {
+        cbAddress = this;
+        owner = msg.sender;
+    }
+
+    event Query(address _contract, address _address, bytes32 _id);
+
+    function queryAddress(address _address) public payable returns (bytes32 _id) {
+        // Generate ID for request.
+        _id = keccak256(this, msg.sender, requestCounters[msg.sender]);
+        requestCounters[msg.sender]++;
+        // Emit a query event.
+        Query(msg.sender, _address, _id);
+    }
+
+    function proxyResponse(IBosonCallbackReceiver _receiver, bytes32 _id, bool _result) public {
+        require(msg.sender == owner);
+        _receiver.__bosonCallback(_id, _result);
+    }
+}
+
+contract TestBosonAddressResolver is IBosonAddressResolver {
+    IBoson boson;
+
+    function TestBosonAddressResolver(IBoson _boson) public {
+        boson = _boson;
+    }
+
+    function getAddress() public returns (address _address) {
+        return boson;
+    }
+}

--- a/dapp/test/crowdsale.js
+++ b/dapp/test/crowdsale.js
@@ -1,0 +1,162 @@
+"use strict";
+
+let Treasurer = artifacts.require('Treasurer');
+let Crowdsale = artifacts.require('Crowdsale');
+let GetToken = artifacts.require('GetToken');
+
+let TestBosonResolver = artifacts.require('TestBosonAddressResolver');
+let TestBoson = artifacts.require('TestBoson');
+
+class TestBosonRunner {
+    constructor() {
+        this.trusted = new Set();
+        this.waiters = [];
+    }
+
+    nextQuery() {
+        let promise = new Promise((resolve, reject) => {
+            this.waiters.push(resolve);
+        });
+        return promise;
+    }
+
+    async processQuery(contract, address, id) {
+        let result = this.trusted.has(address);
+        await this.boson.proxyResponse.sendTransaction(contract, id, result);
+        return result;
+    }
+
+    async start() {
+        this.boson = await TestBoson.new();
+        this.resolver = await TestBosonResolver.new(this.boson.address);
+
+        this.query = this.boson.Query();
+        this.query.watch((error, result) => {
+            if (error) {
+                return;
+            }
+            let address = result.args._address;
+            let contract = result.args._contract;
+            let id = result.args._id;
+
+            // Process query and call contract back.
+            this.processQuery(contract, address, id).then((result) => {
+                // Wake waiters from test code.
+                let waiters = this.waiters.slice();
+                this.waiters = [];
+                for (let waiter of waiters) {
+                    waiter({contract, address, id, result});
+                }
+            });
+        });
+    }
+
+    stop() {
+        this.query.stopWatching();
+    }
+}
+
+
+
+contract('Treasurer', (accounts) => {
+    let deployer = accounts[0];
+    let team = accounts[1];
+    let boson = new TestBosonRunner();
+
+    let treasurer;
+    let token;
+    let crowdsale;
+
+    it("should be deployed successfully", async () => {
+        await boson.start();
+        treasurer = await Treasurer.new(team);
+    });
+
+    it("should have the expected state after construction", async () => {
+        assert.equal((await treasurer.state.call()).valueOf(), 0, "state wasn't Initialized");
+        assert.equal(await treasurer.team.call(), team, "team wasn't set correctly");
+    });
+
+    it("should start and create the token and crowdsale contracts", async () => {
+        await treasurer.start(boson.resolver.address);
+        token = GetToken.at(await treasurer.token.call());
+        crowdsale = Crowdsale.at(await treasurer.crowdsale.call());
+    });
+
+    it("should have sent the team half of the supply of the token", async () => {
+        let totalSupply = await token.totalSupply.call();
+        let teamBalance = await token.balanceOf.call(team);
+        assert.isAbove(totalSupply.valueOf(), 0, "total supply of the token wasn't set correctly");
+        assert.equal(teamBalance.valueOf(), totalSupply.valueOf() / 2, "team account balance wasn't set correctly");
+    });
+
+    it("should have sent the crowdsale contract half of the token", async () => {
+        let totalSupply = await token.totalSupply.call();
+        let crowdsaleBalance = await token.balanceOf.call(crowdsale.address);
+        assert.equal(crowdsaleBalance.valueOf(), totalSupply.valueOf() / 2, "crowdsale account balance wasn't set correctly");
+    });
+
+    it("should have started the crowdsale", async () => {
+        assert.equal((await crowdsale.state.call()).valueOf(), 1, "crowdsale is not started");
+    });
+
+    after(() => {
+        boson.stop();
+    });
+});
+
+contract('Crowdsale', (accounts) => {
+    let token;
+    let crowdsale;
+    let boson = new TestBosonRunner();
+    let initialSupply = 100 * 1000;
+    let ether = 1000000000000000000;
+
+    it("should be deployed correctly", async () => {
+        await boson.start();
+        token = await GetToken.new(accounts[0], initialSupply);
+        crowdsale = await Crowdsale.new(token.address, boson.resolver.address);
+        assert.equal((await crowdsale.state.call()).valueOf(), 0, "crowdsale state hasn't been set");
+        assert.equal(await crowdsale.token.call(), token.address, "crowdsale token hasn't been set");
+        assert.equal(await crowdsale.owner.call(), accounts[0], "crowdsale owner hasn't been set");
+    });
+
+    it("should start correctly", async() => {
+        await token.transfer.sendTransaction(crowdsale.address, initialSupply);
+        await crowdsale.start.sendTransaction();
+        assert.equal((await crowdsale.state.call()).valueOf(), 1, "crowdsale state hasn't changed to started");
+        assert.equal((await crowdsale.tokensLeft.call()).valueOf(), initialSupply, "crowdsale initialSupply hasn't been set");
+        assert.equal((await token.balanceOf(crowdsale.address)).valueOf(), initialSupply, "crowdsale doesn't hold funds");
+    });
+
+    it("should have working approvals", async () => {
+        let buyer = accounts[2];
+
+        assert.equal(await crowdsale.approved.call(buyer), false, "buyer got wrongly approved");
+        await crowdsale.approve.sendTransaction(buyer);
+        await boson.nextQuery();
+        assert.equal(await crowdsale.approved.call(buyer), false, "buyer got wrongly approved");
+        assert.equal(await crowdsale.rejected.call(buyer), true, "buyer didn't get rejected");
+
+        boson.trusted.add(buyer);
+        await crowdsale.approve.sendTransaction(buyer);
+        await boson.nextQuery();
+        assert.equal(await crowdsale.approved.call(buyer), true, "buyer didn't get approved");
+        assert.equal(await crowdsale.rejected.call(buyer), false, "buyer got wrongly rejected");
+    });
+
+    it("should let us buy some tokens", async() => {
+        let buyer = accounts[2];
+        let price = await crowdsale.price.call();
+        let wei = 1 * ether;
+        let tokens = wei / price.toNumber();
+
+        assert.equal((await token.balanceOf.call(buyer)).valueOf(), 0, "buyer owns some tokens already");
+        await crowdsale.buy.sendTransaction(buyer, {value: 1 * ether});
+        assert.equal((await token.balanceOf.call(buyer)).valueOf(), tokens, "buyer didn't receive expected amount of tokens");
+    });
+
+    after(() => {
+        boson.stop();
+    });
+});


### PR DESCRIPTION
This is a Crowdsale contract that:
 - has a fixed pool of tokens to sell
 - has a fixed sale period
 - has a parent Treasury contract that creates the GET token and the
   Crowdsale contract with predefined split
 - has Boson [1] based approvals
 - has tests for basic token sale

It's missing:
 - full functionality (ie. ether withdrawal)
 - testing of sale timeout
 - testing of known bad conditions
 - auditing and failsafe checks